### PR TITLE
add verify_ssl param for ssl verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ upload_to_server(
     headers: {
         //required headers
     },
+    verifySsl: 'false if you want to disable ssl verification' #(Optional - default is true)'
     ipa: 'path to your apk',  #(Optional - will be taken from the gym step)
     apk: 'path to your ipa', #(Optional - will be taken from the gradle step) 
     file: 'path to your custom file'

--- a/lib/fastlane/plugin/upload_to_server/actions/upload_to_server_action.rb
+++ b/lib/fastlane/plugin/upload_to_server/actions/upload_to_server_action.rb
@@ -17,6 +17,8 @@ module Fastlane
         params[:multipartPayload] = config[:multipartPayload]
         params[:headers] = config[:headers]
 
+        params[:verifySsl] = config[:verifySsl]
+
         apk_file = params[:apk]
         ipa_file = params[:ipa]
         custom_file = params[:file]
@@ -53,6 +55,7 @@ module Fastlane
           url: params[:endPoint],
           payload: multipart_payload,
           headers: params[:headers],
+          verify_ssl: params[:verifySsl],
           log: Logger.new(STDOUT)
         )
 
@@ -80,6 +83,12 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :verifySsl,
+                                  env_name: "",
+                                  description: "enable or disable ssl verification",
+                                  optional: true,
+                                  default_value: true,
+                                  type: Boolean),
           FastlaneCore::ConfigItem.new(key: :apk,
                                   env_name: "",
                                   description: ".apk file for the build",


### PR DESCRIPTION
To have the ability to disable&enable the ssl verification **`verify_ssl`** param added for ssl verification. Default value is true